### PR TITLE
Use factories from gov_uk_content_models

### DIFF
--- a/lib/odi_content_models/test_helpers/factories.rb
+++ b/lib/odi_content_models/test_helpers/factories.rb
@@ -3,39 +3,9 @@ require "answer_edition"
 require "artefact"
 require "tag"
 require "user"
+require "govuk_content_models/test_helpers/factories"
 
 FactoryGirl.define do
-  
-  factory :user do
-    sequence(:uid) { |n| "uid-#{n}"}
-    sequence(:name) { |n| "Joe Bloggs #{n}" }
-    sequence(:email) { |n| "joe#{n}@bloggs.com" }
-    if defined?(GDS::SSO::Config)
-      # Grant permission to signin to the app using the gem
-      permissions { ["signin"] }
-    end
-  end
-  
-  factory :artefact do
-    sequence(:name) { |n| "Artefact #{n}" }
-    sequence(:slug) { |n| "slug-#{n}" }
-    kind            Artefact::FORMATS.first
-    owning_app      'publisher'
-  end
-  
-  factory :edition, class: AnswerEdition do
-    panopticon_id {
-        a = create(:artefact)
-        a.id
-      }
-
-    sequence(:slug) { |n| "slug-#{n}" }
-    sequence(:title) { |n| "A key answer to your question #{n}" }
-
-    section "test:subsection test"
-
-    association :assigned_to, factory: :user
-  end
   
   factory :case_study_edition, parent: :edition, :class => 'CaseStudyEdition' do
   end


### PR DESCRIPTION
To make life easier when testing contentapi, we're pulling in the gov_uk_content_models factories, so they can be used elsewhere without getting errors about already registered factories
