### PR TITLE
Remove team from PersonEdition

### DIFF
--- a/app/models/person_edition.rb
+++ b/app/models/person_edition.rb
@@ -10,7 +10,6 @@ class PersonEdition < Edition
   field    :affiliation,      type: String
   # name: uses artefact name
   field    :role,             type: String
-  field    :team,             type: String
   field    :description,      type: String
   field    :url,              type: String
   field    :telephone,        type: String


### PR DESCRIPTION
Actually, that last change may not be appropriate, as People can be members of multiple teams, so am going to handle this using tags.
