### PR TITLE
Change default tag for a User's auto generated Person

### DIFF
--- a/app/decorators/models/user_decorator.rb
+++ b/app/decorators/models/user_decorator.rb
@@ -17,7 +17,7 @@ class User
                 :kind          => "Person", 
                 :owning_app    => "publisher", 
                 :tag_ids       => ["people"],
-                :person        => ["people/staff"],
+                :person        => ["writers"],
                 :rendering_app => "frontend"
               )
        a.save

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -17,7 +17,7 @@ class UserTest < ActiveSupport::TestCase
       }
     }
     # Create a staff tag for testing purposes, ordinarily this would just exist
-    Tag.create(title: "Staff", tag_type: "person", tag_id: "people/staff")
+    Tag.create(title: "Team", tag_type: "person", tag_id: "writers")
     @user = User.find_for_gds_oauth(auth_hash).reload
   end
   


### PR DESCRIPTION
User's have people autogenerated, yeah? And they have a default tag of "team", but now all People with a tag of "team" need to hhave a team specified (i.e. Commercial Team etc), and we don't know what that is going to be necessarily. I've got round this by altering the default that to "writers", which can be changed at a later date.

This needs a more elegant solution going forward.
