### PR TITLE
Add URL to course instance

### DIFF
--- a/app/models/course_instance_edition.rb
+++ b/app/models/course_instance_edition.rb
@@ -9,11 +9,12 @@ class CourseInstanceEdition < Edition
   field :location,      type: String
   field :price,         type: String
   field :description,   type: String
+  field :url,           type: String
   field :trainers,      type: Array # need a way of selecting multiple people here
 
   GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:description]
   
-  @fields_to_clone = [:course, :date, :location, :price, :description, :trainers]
+  @fields_to_clone = [:course, :date, :location, :price, :description, :trainers, :url]
 
   def whole_body
     description


### PR DESCRIPTION
We need to have a booking URL for a course instance - forgot to add this in the initial content model
