### PR TITLE
Assign user profile to existing Person if one exists

### DIFF
--- a/app/decorators/models/user_decorator.rb
+++ b/app/decorators/models/user_decorator.rb
@@ -8,24 +8,29 @@ class User
   
   protected
   
-  # Create a draft profile for the user. This can then be edited at a later time
+  # Attempt to find a profile for the user, otherwise a draft profile. This can then be edited at a later time
   def create_profile
     if self.profile.nil?
-       a = Artefact.create(
-                :name          => self.name.titleize, 
-                :slug          => self.name.parameterize,
-                :kind          => "Person", 
-                :owning_app    => "publisher", 
-                :tag_ids       => ["people"],
-                :person        => ["writers"],
-                :rendering_app => "frontend"
-              )
-       a.save
+       edition = PersonEdition.where(:title => self.name.titleize).first
+       if edition.nil?      
+         a = Artefact.create(
+                  :name          => self.name.titleize, 
+                  :slug          => self.name.parameterize,
+                  :kind          => "Person", 
+                  :owning_app    => "publisher", 
+                  :tag_ids       => ["people"],
+                  :person        => ["writers"],
+                  :rendering_app => "frontend"
+                )
+         a.save
        
-       edition = Edition.find_or_create_from_panopticon_data(a._id, self, nil)
-       edition.save
-       self.profile = a.slug
-       self.save
+         edition = Edition.find_or_create_from_panopticon_data(a._id, self, nil)
+         edition.save
+         self.profile = a.slug
+      else
+        self.profile = edition.slug
+      end
+      self.save
     end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class UserTest < ActiveSupport::TestCase
   
   def setup
-    auth_hash = {
+    @auth_hash = {
       "uid" => "1234abcd",
       "info" => {
         "uid"     => "1234abcd",
@@ -18,16 +18,21 @@ class UserTest < ActiveSupport::TestCase
     }
     # Create a staff tag for testing purposes, ordinarily this would just exist
     Tag.create(title: "Team", tag_type: "person", tag_id: "writers")
-    @user = User.find_for_gds_oauth(auth_hash).reload
   end
   
-  test "should have a profile assigned" do
-    assert_equal "luther-blisset", @user.profile
+  test "should use an exisiting profile if one does exist" do
+    artefact = FactoryGirl.create(:artefact)
+    PersonEdition.create(title: "Luther Blisset", panopticon_id: artefact.id, slug: "luther-blisset")
+    user = User.find_for_gds_oauth(@auth_hash).reload
+    assert_equal "luther-blisset", user.profile
   end
   
-  test "should create a profile" do
-    artefact = Artefact.find_by_slug(@user.profile)
+  test "should create a profile if one doesn't exist" do
+    assert_equal 0, PersonEdition.count
+    user = User.find_for_gds_oauth(@auth_hash).reload
+    artefact = Artefact.find_by_slug(user.profile)
     edition = Edition.where(panopticon_id: artefact._id).first
+    assert_equal "luther-blisset", user.profile
     refute_nil artefact
     refute_nil edition
   end


### PR DESCRIPTION
When creating new users in the Mongo database, we were creating new PersonEditions, which is not ideal given we've already got most people in the content DB now. This PR fixes this, and attempts to find an existing PersonEdition with that name before creating a new one. This is not ideal, but should work as long as we make sure the User has the same name as their corresponding PersonEdition.
