### PR TITLE
Delegate rendering paths and apps to editions if available

### DIFF
--- a/app/decorators/models/artefact_decorator.rb
+++ b/app/decorators/models/artefact_decorator.rb
@@ -34,6 +34,21 @@ class Artefact
   stores_tags_for :sections, :writing_teams, :propositions,
                   :keywords, :legacy_sources, :team, category_tags
   
+  def editions
+    Edition.where(panopticon_id: self.id)
+  end
+  
+  def rendering_path(edition = nil)
+    e = edition || editions.last
+    e.respond_to?(:rendering_path) ? e.rendering_path : "/#{slug}"
+  end
+
+  def rendering_app_with_edition(edition = nil)
+    e = edition || editions.last
+    e.respond_to?(:rendering_app) ? e.rendering_app : rendering_app_without_edition
+  end
+  alias_method_chain :rendering_app, :edition
+
   private
   
   def check_tags

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -13,5 +13,22 @@ class ArtefactTest < ActiveSupport::TestCase
       assert_equal false, artefact.valid?
     end
   end
-    
+   
+  should "delegate rendering path to edition if possible" do
+    FactoryGirl.create(:tag, :tag_id => "team", :tag_type => 'person', :title => "Team Member")
+    FactoryGirl.create(:tag, :tag_id => "technical", :tag_type => 'team', :title => "Tech Team")
+    artefact = FactoryGirl.create(:artefact, :person => ['team'], :team => ['technical'])
+    n = PersonEdition.create(:title         => "Person", 
+                             :panopticon_id => artefact.id,
+                             :slug          => "testing")
+    assert_equal '/team/testing', artefact.rendering_path                            
+    assert_equal 'www', artefact.rendering_app
+  end
+   
+  should "generate default rendering path if no editions available" do
+    artefact = FactoryGirl.create(:artefact, slug: "batman", rendering_app: "gotham")
+    assert_equal '/batman', artefact.rendering_path                            
+    assert_equal 'gotham', artefact.rendering_app
+  end
+
 end


### PR DESCRIPTION
Required to get right web URLs in content API, for theodi/frontend-www#159
