### PR TITLE
Change nodes and organizations to arrays

### DIFF
--- a/app/decorators/models/artefact_decorator.rb
+++ b/app/decorators/models/artefact_decorator.rb
@@ -23,8 +23,8 @@ Artefact::FORMATS = Artefact::FORMATS_BY_DEFAULT_OWNING_APP.values.flatten + gov
 
 class Artefact
   field "author", type: String
-  field "node", type: String
-  field "organization_name", type: String
+  field "node", type: Array
+  field "organization_name", type: Array
   
   validate :check_tags
   validate :check_team

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -7,13 +7,13 @@ class ArtefactTest < ActiveSupport::TestCase
     assert a.valid?
   end
   
-  should "allow a node to be assigned" do
-    a = FactoryGirl.build(:artefact, slug: "its-a-nice-day", node: "llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch")
+  should "allows nodes to be assigned" do
+    a = FactoryGirl.build(:artefact, slug: "its-a-nice-day", node: ["llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch", "westward-ho"])
     assert a.valid?
   end
   
-  should "allow an organization to be assigned" do
-    a = FactoryGirl.build(:artefact, slug: "its-a-nice-day", organization_name: "wayne-enterprises")
+  should "allows organizations to be assigned" do
+    a = FactoryGirl.build(:artefact, slug: "its-a-nice-day", organization_name: ["wayne-enterprises", "arkham-asylum"])
     assert a.valid?
   end
   


### PR DESCRIPTION
So that we can do multiple assignment. We've not got any of this in use yet, so I think it's safe to change without worrying about migrating data. For theodi/panopticon#36
