### PR TITLE
Add livestream field

### DIFF
--- a/app/models/event_edition.rb
+++ b/app/models/event_edition.rb
@@ -9,11 +9,12 @@ class EventEdition < Edition
   field :booking_url, type: String
   # map "image" is generated from location
   field :hashtag,     type: String
+  field :livestream,  type: Boolean
   
   GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:description]
 
   @fields_to_clone = [  
-    :start_date, :end_date, :location, :description, :booking_url, :hashtag
+    :start_date, :end_date, :location, :description, :booking_url, :hashtag, :livestream
   ]
 
   def whole_body

--- a/test/models/event_edition_test.rb
+++ b/test/models/event_edition_test.rb
@@ -13,6 +13,7 @@ class EventEditionTest < ActiveSupport::TestCase
     n.description = "description"
     n.booking_url = "http://eventbrite.com/test"
     n.hashtag = "testing"
+    n.livestream = true
     
     n.safely.save!
 
@@ -23,6 +24,7 @@ class EventEditionTest < ActiveSupport::TestCase
     assert_equal n.description, "description"
     assert_equal n.booking_url, "http://eventbrite.com/test"
     assert_equal n.hashtag, "testing"
+    assert_equal n.livestream, true
   end
   
   should "give a friendly (legacy supporting) description of its format" do
@@ -39,7 +41,8 @@ class EventEditionTest < ActiveSupport::TestCase
                             :location => "Shoreditch",
                             :description => "description",
                             :booking_url => "http://eventbrite.com/test",
-                            :hashtag => "testing")
+                            :hashtag => "testing",
+                            :livestream => true)
       expected = "description"
       assert_equal expected, n.whole_body
     end
@@ -54,7 +57,8 @@ class EventEditionTest < ActiveSupport::TestCase
                           :description => "description",
                           :booking_url => "http://eventbrite.com/test",
                           :hashtag => "testing",
-                          :state => "published")
+                          :state => "published",
+                          :livestream => true)
     new_event = event.build_clone
 
     assert_equal event.start_date, new_event.start_date
@@ -63,6 +67,7 @@ class EventEditionTest < ActiveSupport::TestCase
     assert_equal event.description, new_event.description
     assert_equal event.booking_url, new_event.booking_url
     assert_equal event.hashtag, new_event.hashtag
+    assert_equal event.livestream, new_event.livestream
   end
 
   context "generating paths" do


### PR DESCRIPTION
At the moment, we have a livestream widget displayed against every forthcoming lecture. We want this to be optional, as there are ocassions when the livestream might not be happening (i.e. lack of staff, or the lecture is in another venue). Before, we've had to comment out the code in the www repo, which isn't ideal.
