### PR TITLE
Fix node logos

### DIFF
--- a/app/models/node_edition.rb
+++ b/app/models/node_edition.rb
@@ -24,12 +24,9 @@ class NodeEdition < Edition
 
   attaches_with_metadata :logo
   
-  
   GOVSPEAK_FIELDS = Edition::GOVSPEAK_FIELDS + [:description]
 
-  @fields_to_clone = [
-    :level, :beta, :region, :area, :location, :join_date, :description, :statement, :telephone, :email, :twitter, :linkedin, :host, :url, :active
-  ]
+  clone_fields :level, :beta, :region, :area, :location, :join_date, :description, :statement, :telephone, :email, :twitter, :linkedin, :host, :url, :active
 
   def whole_body
     description


### PR DESCRIPTION
Node logos weren't getting cloned because the :fields_to_clone array was getting overwritten. I've changed the node model to use the (up to date) `clone_fields` method, which fixes this.
