### PR TITLE
Upgrade govuk_content_models to 6.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
   remote: .
   specs:
     odi_content_models (0.0.1)
-      govuk_content_models (= 6.0.6)
+      govuk_content_models (= 6.1.0)
       mongoid_spacial
 
 GEM
@@ -64,20 +64,20 @@ GEM
       activesupport (>= 3.0.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    gds-sso (3.1.1)
-      omniauth-gds (~> 0.0.3)
+    gds-sso (9.2.3)
+      omniauth-gds (>= 3.0.0)
       rack-accept (~> 0.4.4)
       rails (>= 3.0.0)
       warden (~> 1.2)
-    govspeak (1.5.0)
+    govspeak (1.5.1)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (6.0.6)
+    govuk_content_models (6.1.0)
       bson_ext
       differ
       gds-api-adapters
-      gds-sso (>= 3.0.0, < 4.0.0)
+      gds-sso (>= 7.0.0, < 10.0.0)
       govspeak (>= 1.0.1, < 2.0.0)
       mongoid (~> 2.5)
       plek
@@ -100,7 +100,7 @@ GEM
       treetop (~> 1.4.8)
     metaclass (0.0.4)
     mime-types (1.25.1)
-    mini_portile (0.5.2)
+    mini_portile (0.5.3)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
     mongo (1.9.2)
@@ -126,7 +126,7 @@ GEM
     omniauth (1.2.1)
       hashie (>= 1.2, < 3)
       rack (~> 1.0)
-    omniauth-gds (0.0.4)
+    omniauth-gds (3.0.0)
       omniauth-oauth2 (~> 1.0)
     omniauth-oauth2 (1.1.1)
       oauth2 (~> 0.8.0)
@@ -138,7 +138,7 @@ GEM
       rack (>= 0.4)
     rack-cache (1.2)
       rack (>= 0.4)
-    rack-ssl (1.3.3)
+    rack-ssl (1.3.4)
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -172,13 +172,13 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     state_machine (1.2.0)
-    thor (0.18.1)
+    thor (0.19.1)
     tilt (1.4.1)
     timecop (0.5.9.2)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.38)
+    tzinfo (0.3.39)
     warden (1.2.3)
       rack (>= 1.0)
     webmock (1.8.7)

--- a/odi_content_models.gemspec
+++ b/odi_content_models.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib", "app"]
   gem.version       = OdiContentModels::VERSION
 
-  gem.add_dependency "govuk_content_models", "6.0.6"
+  gem.add_dependency "govuk_content_models", "6.1.0"
   gem.add_dependency "mongoid_spacial"
 
   gem.add_development_dependency "database_cleaner", "0.7.2"


### PR DESCRIPTION
Need this so panopticon can upgrade gds-sso.
