### PR TITLE
Fix/publisher 135

### DIFF
--- a/app/decorators/models/edition_decorator.rb
+++ b/app/decorators/models/edition_decorator.rb
@@ -17,14 +17,6 @@ class Edition
     end
   end
 
-  private
-  
-  def tag_to_rendering_path(url_map)
-    section = artefact.tags.map{|x| url_map[x.tag_id]}.compact.uniq.join
-    section = url_map[:default] if section.blank? && url_map[:default]
-    "#{'/' unless section.blank?}#{section}/#{slug}"
-  end
-
   def update_from_artefact(artefact)
     ####################################################################
     # Removing the update to title. This action is triggered when there
@@ -43,6 +35,14 @@ class Edition
     self.department = artefact.department
     self.business_proposition = artefact.business_proposition
     self.save!
+  end
+
+  private
+  
+  def tag_to_rendering_path(url_map)
+    section = artefact.tags.map{|x| url_map[x.tag_id]}.compact.uniq.join
+    section = url_map[:default] if section.blank? && url_map[:default]
+    "#{'/' unless section.blank?}#{section}/#{slug}"
   end
 
 end

--- a/app/decorators/models/edition_decorator.rb
+++ b/app/decorators/models/edition_decorator.rb
@@ -25,4 +25,24 @@ class Edition
     "#{'/' unless section.blank?}#{section}/#{slug}"
   end
 
+  def update_from_artefact(artefact)
+    ####################################################################
+    # Removing the update to title. This action is triggered when there
+    # is an update to the artefact in Panopticon. Agreed with @pezolio
+    # on 17 June to comment out, in case VERY BAD THINGS happen.
+    # slug is the prime linkage, but think that section, department and
+    # business_proposition are mastered in Panopticon / artefact, so
+    # should maintain them there, and ensure that existing editions are
+    # updated.
+    # The issue is here: https://github.com/theodi/publisher/issues/135
+    #
+
+    # self.title = artefact.name unless published?
+    self.slug = artefact.slug
+    self.section = artefact.section
+    self.department = artefact.department
+    self.business_proposition = artefact.business_proposition
+    self.save!
+  end
+
 end

--- a/lib/odi_content_models.rb
+++ b/lib/odi_content_models.rb
@@ -11,6 +11,27 @@ begin
         end
       end
     end
+    class Edition
+      def update_from_artefact(artefact)
+        ####################################################################
+        # Removing the update to title. This action is triggered when there
+        # is an update to the artefact in Panopticon. Agreed with @pezolio
+        # on 17 June to comment out, in case VERY BAD THINGS happen.
+        # slug is the prime linkage, but think that section, department and
+        # business_proposition are mastered in Panopticon / artefact, so
+        # should maintain them there, and ensure that existing editions are
+        # updated.
+        # The issue is here: https://github.com/theodi/publisher/issues/135
+        #
+
+        # self.title = artefact.name unless published?
+        self.slug = artefact.slug
+        self.section = artefact.section
+        self.department = artefact.department
+        self.business_proposition = artefact.business_proposition
+        self.save!
+      end
+    end
   end
 rescue NameError
   module OdiContentModels

--- a/lib/odi_content_models.rb
+++ b/lib/odi_content_models.rb
@@ -11,27 +11,6 @@ begin
         end
       end
     end
-    class Edition
-      def update_from_artefact(artefact)
-        ####################################################################
-        # Removing the update to title. This action is triggered when there
-        # is an update to the artefact in Panopticon. Agreed with @pezolio
-        # on 17 June to comment out, in case VERY BAD THINGS happen.
-        # slug is the prime linkage, but think that section, department and
-        # business_proposition are mastered in Panopticon / artefact, so
-        # should maintain them there, and ensure that existing editions are
-        # updated.
-        # The issue is here: https://github.com/theodi/publisher/issues/135
-        #
-
-        # self.title = artefact.name unless published?
-        self.slug = artefact.slug
-        self.section = artefact.section
-        self.department = artefact.department
-        self.business_proposition = artefact.business_proposition
-        self.save!
-      end
-    end
   end
 rescue NameError
   module OdiContentModels


### PR DESCRIPTION
Monkey patching Editions to override the update_from_artefact method. Needed to stop it changing the title when the Artefact changes (either direct in Panopticon, or via keyword tagging).

Resolves https://github.com/theodi/publisher/issues/135, as long as the dependent services are rebuilt... All of them... (`publisher`, `panopticon` and `contentapi`, by my reckoning)